### PR TITLE
Refactored lazy delegation in fragments, polished history views

### DIFF
--- a/app/src/main/java/com/iprogrammerr/foodcontroller/view/fragment/CategoriesFragment.kt
+++ b/app/src/main/java/com/iprogrammerr/foodcontroller/view/fragment/CategoriesFragment.kt
@@ -5,7 +5,6 @@ import android.content.Context
 import android.databinding.DataBindingUtil
 import android.os.Bundle
 import android.support.v4.app.Fragment
-import android.support.v7.widget.LinearLayoutManager
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -13,7 +12,7 @@ import com.iprogrammerr.foodcontroller.R
 import com.iprogrammerr.foodcontroller.databinding.FragmentCategoriesBinding
 import com.iprogrammerr.foodcontroller.model.IdTarget
 import com.iprogrammerr.foodcontroller.model.result.LifecycleCallback
-import com.iprogrammerr.foodcontroller.view.LinearOffsetDecoration
+import com.iprogrammerr.foodcontroller.model.scalar.GridOrLinear
 import com.iprogrammerr.foodcontroller.view.RootView
 import com.iprogrammerr.foodcontroller.view.dialog.ErrorDialog
 import com.iprogrammerr.foodcontroller.view.items.CategoriesView
@@ -33,10 +32,10 @@ class CategoriesFragment : Fragment(), IdTarget {
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?): View? {
-        val binding: FragmentCategoriesBinding =
-            DataBindingUtil.inflate(inflater, R.layout.fragment_categories, container, false)
-        binding.categories.layoutManager = LinearLayoutManager(this.context)
-        binding.categories.addItemDecoration(LinearOffsetDecoration(requireContext()))
+        val binding: FragmentCategoriesBinding = DataBindingUtil.inflate(
+            inflater, R.layout.fragment_categories, container, false
+        )
+        binding.categories.layoutManager = GridOrLinear(this.context!!, binding.categories).value()
         this.viewModel.categories(LifecycleCallback(this) { r ->
             if (r.isSuccess()) {
                 binding.categories.adapter = CategoriesView(r.value(), this)

--- a/app/src/main/java/com/iprogrammerr/foodcontroller/view/fragment/CategoryFoodDefinitionsFragment.kt
+++ b/app/src/main/java/com/iprogrammerr/foodcontroller/view/fragment/CategoryFoodDefinitionsFragment.kt
@@ -41,14 +41,7 @@ class CategoryFoodDefinitionsFragment : Fragment(), TextWatcher, IdTarget, Adapt
     private val id by lazy {
         this.arguments?.let { it.getLong(ID, -1) } ?: -1
     }
-    private val viewModel by lazy {
-        ViewModelProviders.of(
-            this,
-            CategoryFoodDefinitionsViewModel.factory(
-                DatabaseCategory(this.id, ObjectsPool.single(Database::class.java))
-            )
-        ).get(CategoryFoodDefinitionsViewModel::class.java)
-    }
+    private lateinit var viewModel: CategoryFoodDefinitionsViewModel
 
     companion object {
 
@@ -67,6 +60,12 @@ class CategoryFoodDefinitionsFragment : Fragment(), TextWatcher, IdTarget, Adapt
     override fun onAttach(context: Context?) {
         super.onAttach(context)
         this.root = context as RootView
+        this.viewModel = ViewModelProviders.of(
+            this,
+            CategoryFoodDefinitionsViewModel.factory(
+                DatabaseCategory(this.id, ObjectsPool.single(Database::class.java))
+            )
+        ).get(CategoryFoodDefinitionsViewModel::class.java)
     }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?,
@@ -141,7 +140,7 @@ class CategoryFoodDefinitionsFragment : Fragment(), TextWatcher, IdTarget, Adapt
     }
 
     override fun hit(message: Message) {
-        if (message == Message.FOOD_DEFINITION_CHANGED || message == Message.FOOD_DEFINITION_MOVED) {
+        if (this::viewModel.isInitialized && message == Message.FOOD_DEFINITION_CHANGED || message == Message.FOOD_DEFINITION_MOVED) {
             this.viewModel.refresh()
             if (this.lifecycle.currentState.isAtLeast(Lifecycle.State.CREATED)) {
                 drawAllOrFiltered()

--- a/app/src/main/java/com/iprogrammerr/foodcontroller/view/fragment/FoodFragment.kt
+++ b/app/src/main/java/com/iprogrammerr/foodcontroller/view/fragment/FoodFragment.kt
@@ -29,9 +29,7 @@ class FoodFragment : Fragment(), TextWatcher, IdTarget, MessageTarget {
     private lateinit var root: RootView
     private lateinit var binding: FragmentFoodBinding
     private lateinit var food: FoodDefinitionsView
-    private val viewModel by lazy {
-        ViewModelProviders.of(this).get(FoodViewModel::class.java)
-    }
+    private lateinit var viewModel: FoodViewModel
 
     companion object {
 
@@ -50,6 +48,7 @@ class FoodFragment : Fragment(), TextWatcher, IdTarget, MessageTarget {
     override fun onAttach(context: Context?) {
         super.onAttach(context)
         this.root = context as RootView
+        this.viewModel = ViewModelProviders.of(this).get(FoodViewModel::class.java)
     }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?,
@@ -96,17 +95,11 @@ class FoodFragment : Fragment(), TextWatcher, IdTarget, MessageTarget {
 
     }
 
-    override fun beforeTextChanged(
-        s: CharSequence?, start: Int, count: Int,
-        after: Int
-    ) {
+    override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) {
 
     }
 
-    override fun onTextChanged(
-        s: CharSequence?, start: Int, before: Int,
-        count: Int
-    ) {
+    override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {
         s?.let {
             val criteria = s.toString()
             val args = this.arguments as Bundle
@@ -128,7 +121,7 @@ class FoodFragment : Fragment(), TextWatcher, IdTarget, MessageTarget {
     }
 
     override fun hit(message: Message) {
-        if (message == Message.FOOD_DEFINITION_CHANGED) {
+        if (this::viewModel.isInitialized && message == Message.FOOD_DEFINITION_CHANGED) {
             this.viewModel.refresh()
         }
     }

--- a/app/src/main/java/com/iprogrammerr/foodcontroller/view/fragment/FoodPortionFragment.kt
+++ b/app/src/main/java/com/iprogrammerr/foodcontroller/view/fragment/FoodPortionFragment.kt
@@ -64,10 +64,8 @@ class FoodPortionFragment : Fragment(), TextWatcher {
         this.root = context as RootView
     }
 
-    override fun onCreateView(
-        inflater: LayoutInflater, container: ViewGroup?,
-        savedInstanceState: Bundle?
-    ): View? {
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?,
+        savedInstanceState: Bundle?): View? {
         this.binding = DataBindingUtil.inflate(
             inflater, R.layout.fragment_food_portion, container, false
         )

--- a/app/src/main/java/com/iprogrammerr/foodcontroller/view/fragment/MealFragment.kt
+++ b/app/src/main/java/com/iprogrammerr/foodcontroller/view/fragment/MealFragment.kt
@@ -28,15 +28,7 @@ class MealFragment : Fragment(), TimeDialog.Target, MessageTarget, FoodWithActio
 
     private lateinit var root: RootView
     private lateinit var binding: FragmentMealBinding
-    private val viewModel by lazy {
-        val mealId = this.arguments!!.getLong(MEAL_ID, -1)
-        if (mealId < 0) {
-            ViewModelProviders.of(this).get(MealViewModel::class.java)
-        } else {
-            ViewModelProviders.of(this, MealViewModel.factory(mealId))
-                .get(MealViewModel::class.java)
-        }
-    }
+    private lateinit var viewModel: MealViewModel
 
     companion object {
 
@@ -60,6 +52,13 @@ class MealFragment : Fragment(), TimeDialog.Target, MessageTarget, FoodWithActio
     override fun onAttach(context: Context?) {
         super.onAttach(context)
         this.root = context as RootView
+        val mealId = this.arguments!!.getLong(MEAL_ID, -1)
+        this.viewModel = if (mealId < 0) {
+            ViewModelProviders.of(this).get(MealViewModel::class.java)
+        } else {
+            ViewModelProviders.of(this, MealViewModel.factory(mealId))
+                .get(MealViewModel::class.java)
+        }
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -153,7 +152,7 @@ class MealFragment : Fragment(), TimeDialog.Target, MessageTarget, FoodWithActio
     }
 
     override fun hit(message: Message) {
-        if (message == Message.PORTIONS_CHANGED || message == Message.MEAL_CHANGED) {
+        if (this::viewModel.isInitialized && (message == Message.PORTIONS_CHANGED || message == Message.MEAL_CHANGED)) {
             this.viewModel.refresh()
             this.root.propagate(Message.MEALS_CHANGED)
         }

--- a/app/src/main/java/com/iprogrammerr/foodcontroller/view/fragment/MenuFragment.kt
+++ b/app/src/main/java/com/iprogrammerr/foodcontroller/view/fragment/MenuFragment.kt
@@ -35,7 +35,7 @@ class MenuFragment : Fragment(), WeightDialog.Target, TwoOptionsDialog.Target {
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?): View? {
         this.binding = DataBindingUtil.inflate(inflater, R.layout.fragment_menu, container, false)
-        this.root.changeTitle(getString(R.string.menu))
+        this.root.changeTitle(getString(R.string.app_name))
         this.binding.history.setOnClickListener { this.root.replace(YearsFragment(), true) }
         this.binding.base.setOnClickListener { this.root.replace(CategoriesFragment(), true) }
         this.binding.goals.setOnClickListener { this.root.replace(GoalsFragment(), true) }

--- a/app/src/main/java/com/iprogrammerr/foodcontroller/view/fragment/MonthsFragment.kt
+++ b/app/src/main/java/com/iprogrammerr/foodcontroller/view/fragment/MonthsFragment.kt
@@ -5,13 +5,13 @@ import android.content.Context
 import android.databinding.DataBindingUtil
 import android.os.Bundle
 import android.support.v4.app.Fragment
-import android.support.v7.widget.LinearLayoutManager
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import com.iprogrammerr.foodcontroller.R
 import com.iprogrammerr.foodcontroller.databinding.FragmentMonthsBinding
 import com.iprogrammerr.foodcontroller.model.result.LifecycleCallback
+import com.iprogrammerr.foodcontroller.model.scalar.GridOrLinear
 import com.iprogrammerr.foodcontroller.view.RootView
 import com.iprogrammerr.foodcontroller.view.dialog.ErrorDialog
 import com.iprogrammerr.foodcontroller.view.items.AdapterTarget
@@ -24,11 +24,7 @@ import java.util.*
 class MonthsFragment : Fragment(), AdapterTarget<Calendar>, MessageTarget {
 
     private lateinit var root: RootView
-    private val viewModel by lazy {
-        ViewModelProviders.of(
-            this, MonthsViewModel.factory(this.arguments!!.getInt(YEAR))
-        ).get(MonthsViewModel::class.java)
-    }
+    private lateinit var viewModel: MonthsViewModel
 
     companion object {
 
@@ -46,6 +42,10 @@ class MonthsFragment : Fragment(), AdapterTarget<Calendar>, MessageTarget {
     override fun onAttach(context: Context?) {
         super.onAttach(context)
         this.root = context as RootView
+        this.viewModel = ViewModelProviders.of(
+            this,
+            MonthsViewModel.factory(this.arguments!!.getInt(YEAR))
+        ).get(MonthsViewModel::class.java)
     }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?,
@@ -53,19 +53,19 @@ class MonthsFragment : Fragment(), AdapterTarget<Calendar>, MessageTarget {
         val binding: FragmentMonthsBinding = DataBindingUtil.inflate(
             inflater, R.layout.fragment_months, container, false
         )
+        binding.months.layoutManager = GridOrLinear(this.context!!, binding.months).value()
         this.viewModel.months(LifecycleCallback(this) { r ->
             if (r.isSuccess()) {
                 if (r.value().isEmpty()) {
                     requireFragmentManager().popBackStack()
                 } else {
-                    binding.months.layoutManager = LinearLayoutManager(this.context)
                     binding.months.adapter = MonthsView(r.value(), this)
                 }
             } else {
                 ErrorDialog.new(r.exception()).show(this.childFragmentManager)
             }
         })
-        this.root.changeTitle(getString(R.string.months))
+        this.root.changeTitle(this.arguments!!.getInt(YEAR).toString())
         return binding.root
     }
 
@@ -74,7 +74,7 @@ class MonthsFragment : Fragment(), AdapterTarget<Calendar>, MessageTarget {
     }
 
     override fun hit(message: Message) {
-        if (message == Message.DAYS_CHANGED) {
+        if (this::viewModel.isInitialized && message == Message.DAYS_CHANGED) {
             this.viewModel.refresh()
         }
     }

--- a/app/src/main/java/com/iprogrammerr/foodcontroller/view/fragment/YearsFragment.kt
+++ b/app/src/main/java/com/iprogrammerr/foodcontroller/view/fragment/YearsFragment.kt
@@ -12,6 +12,7 @@ import android.view.ViewGroup
 import com.iprogrammerr.foodcontroller.R
 import com.iprogrammerr.foodcontroller.databinding.FragmentYearsBinding
 import com.iprogrammerr.foodcontroller.model.result.LifecycleCallback
+import com.iprogrammerr.foodcontroller.model.scalar.GridOrLinear
 import com.iprogrammerr.foodcontroller.view.RootView
 import com.iprogrammerr.foodcontroller.view.dialog.ErrorDialog
 import com.iprogrammerr.foodcontroller.view.items.AdapterTarget
@@ -24,13 +25,12 @@ class YearsFragment : Fragment(), AdapterTarget<Int>, MessageTarget {
 
     private lateinit var root: RootView
     private lateinit var binding: FragmentYearsBinding
-    private val viewModel by lazy {
-        ViewModelProviders.of(this).get(YearsViewModel::class.java)
-    }
+    private lateinit var viewModel: YearsViewModel
 
     override fun onAttach(context: Context?) {
         super.onAttach(context)
         this.root = context as RootView
+        this.viewModel = ViewModelProviders.of(this).get(YearsViewModel::class.java)
     }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?,
@@ -55,7 +55,7 @@ class YearsFragment : Fragment(), AdapterTarget<Int>, MessageTarget {
             this.binding.ok.visibility = View.VISIBLE
             this.binding.ok.setOnClickListener { requireFragmentManager().popBackStack() }
         } else {
-            this.binding.years.layoutManager = LinearLayoutManager(this.context)
+            this.binding.years.layoutManager = GridOrLinear(requireContext(), binding.years).value()
             this.binding.years.adapter = YearsView(years, this)
         }
     }
@@ -65,7 +65,7 @@ class YearsFragment : Fragment(), AdapterTarget<Int>, MessageTarget {
     }
 
     override fun hit(message: Message) {
-        if (message == Message.DAYS_CHANGED) {
+        if (this::viewModel.isInitialized && message == Message.DAYS_CHANGED) {
             this.viewModel.refresh()
         }
     }

--- a/app/src/main/java/com/iprogrammerr/foodcontroller/viewmodel/DaysViewModel.kt
+++ b/app/src/main/java/com/iprogrammerr/foodcontroller/viewmodel/DaysViewModel.kt
@@ -46,10 +46,12 @@ class DaysViewModel(
         this.asynchronous.execute({ this.days.value() }, callback)
     }
 
-    fun averageConsumption(callback: Callback<NutritionalValues>) {
+    fun statistics(callback: Callback<Pair<NutritionalValues, NutritionalValues>>) {
         this.asynchronous.execute({
             var calories = 0
             var protein = 0.0
+            var caloriesGoal = 0
+            var proteinGoal = 0.0
             if (this.days.value().isNotEmpty()) {
                 for (d in this.days.value()) {
                     for (m in d.meals()) {
@@ -57,16 +59,29 @@ class DaysViewModel(
                         calories += values.calories()
                         protein += values.protein()
                     }
+                    val goals = d.goals()
+                    caloriesGoal += goals.calories()
+                    proteinGoal += goals.protein()
                 }
                 calories /= this.days.value().size
                 protein /= this.days.value().size
+                caloriesGoal /= this.days.value().size
+                proteinGoal /= this.days.value().size
             }
-            object : NutritionalValues {
+            Pair(
+                object : NutritionalValues {
 
-                override fun calories() = calories
+                    override fun calories() = calories
 
-                override fun protein() = protein
-            }
+                    override fun protein() = protein
+                },
+                object : NutritionalValues {
+
+                    override fun calories() = caloriesGoal
+
+                    override fun protein() = proteinGoal
+                }
+            )
         }, callback)
     }
 

--- a/app/src/main/res/layout/fragment_days.xml
+++ b/app/src/main/res/layout/fragment_days.xml
@@ -5,53 +5,98 @@
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:orientation="vertical"
-        android:padding="@dimen/dpSmall">
+        android:orientation="vertical">
 
-        <RelativeLayout
+        <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginBottom="@dimen/dpMedium">
+            android:padding="@dimen/dpSmall"
+            android:orientation="horizontal">
 
             <TextView
-                android:id="@+id/calories"
                 style="@style/TitleStyle"
-                android:layout_width="wrap_content"
+                android:layout_width="0dp"
                 android:layout_height="wrap_content"
-                android:text="@string/calories" />
+                android:layout_weight="1"
+                android:gravity="end"
+                android:layout_marginEnd="@dimen/dpSmall"
+                android:text="@string/calories"
+                android:textColor="@color/caloriesForeground" />
+
+            <ProgressBar
+                android:id="@+id/caloriesProgress"
+                style="?android:attr/progressBarStyleHorizontal"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center"
+                android:layout_weight="2"
+                android:indeterminate="false"
+                android:progressDrawable="@drawable/calories_progress"
+                tools:max="100"
+                tools:progress="78" />
 
             <TextView
                 android:id="@+id/caloriesValue"
-                style="@style/TitleStyle"
-                android:layout_width="wrap_content"
+                style="@style/DescriptionStyle"
+                android:layout_width="0dp"
                 android:layout_height="wrap_content"
-                android:layout_marginStart="@dimen/dpSmall"
-                android:layout_toEndOf="@+id/calories"
-                tools:text="1000" />
+                android:layout_gravity="center"
+                android:layout_marginStart="@dimen/dpLittle"
+                android:layout_weight="1"
+                android:textColor="@color/caloriesForeground"
+                tools:text="1200/3000" />
+        </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:padding="@dimen/dpSmall"
+            android:orientation="horizontal">
 
             <TextView
-                android:id="@+id/protein"
                 style="@style/TitleStyle"
-                android:layout_width="wrap_content"
+                android:layout_width="0dp"
                 android:layout_height="wrap_content"
-                android:layout_below="@+id/calories"
-                android:text="@string/protein_g" />
+                android:layout_weight="1"
+                android:text="@string/protein"
+                android:gravity="end"
+                android:layout_marginEnd="@dimen/dpSmall"
+                android:textColor="@color/proteinForeground" />
+
+            <ProgressBar
+                android:id="@+id/proteinProgress"
+                style="?android:attr/progressBarStyleHorizontal"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center"
+                android:layout_weight="2"
+                android:indeterminate="false"
+                android:progressDrawable="@drawable/protein_progress"
+                tools:max="120"
+                tools:progress="20" />
 
             <TextView
                 android:id="@+id/proteinValue"
-                android:layout_width="wrap_content"
+                style="@style/DescriptionStyle"
+                android:layout_width="0dp"
                 android:layout_height="wrap_content"
-                android:layout_below="@+id/calories"
-                android:layout_toEndOf="@+id/protein"
-                android:layout_marginStart="@dimen/dpSmall"
-                style="@style/TitleStyle"
-                tools:text="100"/>
+                android:layout_gravity="center"
+                android:layout_marginStart="@dimen/dpLittle"
+                android:layout_weight="1"
+                android:textColor="@color/caloriesForeground"
+                tools:text="20/120" />
+        </LinearLayout>
 
-        </RelativeLayout>
+        <View
+            android:layout_width="match_parent"
+            android:layout_height="@dimen/dpLittle"
+            android:background="@color/colorPrimaryDark" />
+
 
         <android.support.v7.widget.RecyclerView
             android:id="@+id/days"
             android:layout_width="match_parent"
-            android:layout_height="match_parent" />
+            android:layout_height="match_parent"
+            android:padding="@dimen/dpSmall" />
     </LinearLayout>
 </layout>


### PR DESCRIPTION
There was a subtle bug in fragments that implement MessageTarget and have refreshable view model. On configuration change it was possible for them to receive message and then crash while telling their view model to refresh its data. That was because view model was then initialized in detached fragment state. Another great example of Android's API simplicity... It is now refactored to lateinit property and is checked where appriopriate.  